### PR TITLE
Add iOS-style modal sheet for gallery items

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,34 +144,34 @@
             <section id="gallery" class="bento-item full-width">
                 <h2>Gallery</h2>
                 <div class="gallery-grid">
-                    <figure class="gallery-item">
+                    <button class="gallery-item" type="button" data-title="Nintendo Switch" data-description="Portable gaming console with a unique hybrid design.">
                         <img src="Resources/Gallery/nintendo-switch.png" alt="Nintendo Switch">
-                        <figcaption class="caption">Nintendo Switch</figcaption>
-                    </figure>
-                    <figure class="gallery-item">
+                        <span class="caption">Nintendo Switch</span>
+                    </button>
+                    <button class="gallery-item" type="button" data-title="Coding mobile applications" data-description="Working on Swift and Kotlin projects.">
                         <img src="Resources/Gallery/coding.png" alt="Coding Mobile Applications">
-                        <figcaption class="caption">Coding mobile applications</figcaption>
-                    </figure>
-                    <figure class="gallery-item">
+                        <span class="caption">Coding mobile applications</span>
+                    </button>
+                    <button class="gallery-item" type="button" data-title="CV paper" data-description="Printed resume and portfolio materials.">
                         <img src="Resources/Gallery/cv-paper.png" alt="CV Paper">
-                        <figcaption class="caption">CV paper</figcaption>
-                    </figure>
-                    <figure class="gallery-item">
+                        <span class="caption">CV paper</span>
+                    </button>
+                    <button class="gallery-item" type="button" data-title="Argentina Flag" data-description="Exploring relocation options starting in Argentina.">
                         <img src="Resources/Gallery/argentina-flag.png" alt="Argentina Flag">
-                        <figcaption class="caption">Argentina Flag</figcaption>
-                    </figure>
-                    <figure class="gallery-item">
+                        <span class="caption">Argentina Flag</span>
+                    </button>
+                    <button class="gallery-item" type="button" data-title="NAS storage" data-description="Personal network storage for safeguarding data.">
                         <img src="Resources/Gallery/nas-storage.png" alt="NAS Storage">
-                        <figcaption class="caption">NAS storage</figcaption>
-                    </figure>
-                    <figure class="gallery-item">
+                        <span class="caption">NAS storage</span>
+                    </button>
+                    <button class="gallery-item" type="button" data-title="Japan" data-description="Future destination to continue tech career.">
                         <img src="Resources/Gallery/japan.png" alt="Japan">
-                        <figcaption class="caption">Japan</figcaption>
-                    </figure>
-                    <figure class="gallery-item">
+                        <span class="caption">Japan</span>
+                    </button>
+                    <button class="gallery-item" type="button" data-title="Kyoto" data-description="Historic city blending tradition with technology.">
                         <img src="Resources/Gallery/kyoto.png" alt="Kyoto">
-                        <figcaption class="caption">Kyoto</figcaption>
-                    </figure>
+                        <span class="caption">Kyoto</span>
+                    </button>
                 </div>
             </section>
 
@@ -215,6 +215,18 @@
         <footer>
             <p>Handmade by Eugene Rozhkov</p>
         </footer>
+    </div>
+    <div id="gallery-modal" class="gallery-modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="modal-title"></h2>
+                <button class="modal-close" aria-label="Close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p id="modal-description"></p>
+                <img id="modal-image" src="" alt="">
+            </div>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -70,3 +70,30 @@ const createMobileMenu = () => {
 
 // Initialize mobile menu
 createMobileMenu();
+
+// Gallery modal functionality
+const galleryModal = document.getElementById('gallery-modal');
+const modalTitle = document.getElementById('modal-title');
+const modalDescription = document.getElementById('modal-description');
+const modalImage = document.getElementById('modal-image');
+const closeButton = galleryModal.querySelector('.modal-close');
+
+document.querySelectorAll('.gallery-item').forEach(item => {
+    item.addEventListener('click', () => {
+        modalTitle.textContent = item.dataset.title;
+        modalDescription.textContent = item.dataset.description;
+        const img = item.querySelector('img');
+        modalImage.src = img.src;
+        modalImage.alt = item.dataset.title;
+        galleryModal.classList.add('open');
+    });
+});
+
+const hideModal = () => galleryModal.classList.remove('open');
+
+closeButton.addEventListener('click', hideModal);
+galleryModal.addEventListener('click', (e) => {
+    if (e.target === galleryModal) {
+        hideModal();
+    }
+});

--- a/styles.css
+++ b/styles.css
@@ -550,6 +550,12 @@ header {
     position: relative;
     overflow: hidden;
     border-radius: var(--border-radius);
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    display: block;
+    width: 100%;
 }
 
 .gallery-item img {
@@ -580,6 +586,89 @@ header {
 
 .gallery-item:hover .caption {
     opacity: 1;
+}
+
+/* Gallery Modal */
+.gallery-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--transition-speed);
+    z-index: 1000;
+}
+
+.gallery-modal.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.gallery-modal .modal-content {
+    background: var(--background-color);
+    width: 100%;
+    max-width: 800px;
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
+    transform: translateY(100%);
+    transition: transform var(--transition-speed);
+    padding: 1.5rem;
+}
+
+.gallery-modal.open .modal-content {
+    transform: translateY(0);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.modal-header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.modal-body {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.modal-body p {
+    flex: 1;
+    margin: 0;
+}
+
+.modal-body img {
+    width: 50%;
+    max-height: 300px;
+    object-fit: cover;
+    border-radius: var(--border-radius);
+}
+
+@media (max-width: 600px) {
+    .modal-body {
+        flex-direction: column;
+    }
+
+    .modal-body img {
+        width: 100%;
+    }
 }
 
 /* Contact Section */


### PR DESCRIPTION
## Summary
- Turn gallery images into interactive buttons with descriptive data
- Introduce animated iOS-style bottom sheet modal with title, description, and close button
- Add JavaScript to populate and control the modal

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b0e68bed88833288ca9250f6c81af5